### PR TITLE
Rated arts show

### DIFF
--- a/app/controllers/api/v1/rated_arts_controller.rb
+++ b/app/controllers/api/v1/rated_arts_controller.rb
@@ -1,4 +1,13 @@
 class Api::V1::RatedArtsController < ApplicationController
+
+  def show
+    art = Art.find(params[:id])
+    user = User.find(params[:user_id])
+    artwork = ArtsyFacade.find_art_by_id(art.artsy_id)
+    rated_art = user.rated_arts.where('art_id =?', params[:id]).first
+    render json: ArtSerializer.art_show(artwork, rated_art)
+  end
+
   def index
     user = User.find(params[:user_id])
     liked_arts = user.rated_arts.where(liked: true)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
       resources :arts, only: [:create]
       resources :categories, only: [:create]
       resources :users do
-        resources :rated_arts, only: [:index]
+        resources :rated_arts, only: [:index, :show]
       end
     end
   end

--- a/spec/requests/api/v1/rated_art_request_spec.rb
+++ b/spec/requests/api/v1/rated_art_request_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'Rated Art Index' do
     @u1.rated_arts.create(liked: false, art_id:3)
     stub_request(:get, "https://api.artsy.net/api/artworks/#{@stub_2['_embedded']['artworks'][0]['id']}?X-Xapp-Token=").to_return(status: 200, body: @stub_2['_embedded']['artworks'][0].to_json, headers: {})
     stub_request(:get, "https://api.artsy.net/api/artworks/#{@stub_2['_embedded']['artworks'][1]['id']}?X-Xapp-Token=").to_return(status: 200, body: @stub_2['_embedded']['artworks'][1].to_json, headers: {})
+    stub_request(:get, "https://api.artsy.net/api/artworks/#{@stub_2['_embedded']['artworks'][2]['id']}?X-Xapp-Token=").to_return(status: 200, body: @stub_2['_embedded']['artworks'][2].to_json, headers: {})
   end
 
   it 'can find a users liked art' do
@@ -47,7 +48,7 @@ RSpec.describe 'Rated Art Index' do
 
   end
 
-  it 'does show page thing' do
+  it 'can return liked art' do
     get "/api/v1/users/#{@u1.id}/rated_arts/#{@u1.rated_arts[0].art_id}" , params: { user_id: @u1.id, id: @u1.rated_arts[0].art_id }
     res = JSON.parse(response.body)
 
@@ -57,6 +58,17 @@ RSpec.describe 'Rated Art Index' do
     expect(res['data']['attributes']['liked']).to eq(true)
     expect(res['data']['attributes']['user_id']).to eq(@u1.id)
     expect(res['data']['attributes']['image']).to be_a(String)
+  end
 
+  it 'can return liked art recommendation' do
+    get "/api/v1/users/#{@u1.id}/rated_arts/#{@u1.rated_arts[2].art_id}" , params: { user_id: @u1.id, id: @u1.rated_arts[2].art_id }
+    res = JSON.parse(response.body)
+
+    expect(res['data']['id']).to eq(3)
+    expect(res['data']['type']).to eq('rated_art')
+    expect(res['data']['attributes']['title']).to eq('The Company of Frans Banning Cocq and Willem van Ruytenburch (The Night Watch)')
+    expect(res['data']['attributes']['liked']).to eq(false)
+    expect(res['data']['attributes']['user_id']).to eq(@u1.id)
+    expect(res['data']['attributes']['image']).to be_a(String)
   end
 end

--- a/spec/requests/api/v1/rated_art_request_spec.rb
+++ b/spec/requests/api/v1/rated_art_request_spec.rb
@@ -10,19 +10,19 @@ RSpec.describe 'Rated Art Index' do
     # @art_2 = Art.create!(artsy_id: '3334')
     # @art_3 = Art.create!(artsy_id: '1414')
 
-    stub_1 = WebmockStubs.mock_art
-    stub_2 = JSON.parse(WebmockStubs.mock_art)
-    
-    
-    stub_request(:get, "https://api.artsy.net/api/artworks?size=5").to_return(status: 200, body: stub_1, headers: {})
-    stub_request(:post, "https://api.artsy.net/api/tokens/xapp_token").to_return(status: 200, body: stub_1, headers: {})
-    
+    @stub_1 = WebmockStubs.mock_art
+    @stub_2 = JSON.parse(WebmockStubs.mock_art)
+
+
+    stub_request(:get, "https://api.artsy.net/api/artworks?size=5").to_return(status: 200, body: @stub_1, headers: {})
+    stub_request(:post, "https://api.artsy.net/api/tokens/xapp_token").to_return(status: 200, body: @stub_1, headers: {})
+
     GetArtFacade.show_me_art(5, 'large')
     @u1.rated_arts.create(liked: true, art_id:1)
     @u1.rated_arts.create(liked: true, art_id:2)
     @u1.rated_arts.create(liked: false, art_id:3)
-    stub_request(:get, "https://api.artsy.net/api/artworks/#{stub_2['_embedded']['artworks'][0]['id']}?X-Xapp-Token=").to_return(status: 200, body: stub_2['_embedded']['artworks'][0].to_json, headers: {})
-    stub_request(:get, "https://api.artsy.net/api/artworks/#{stub_2['_embedded']['artworks'][1]['id']}?X-Xapp-Token=").to_return(status: 200, body: stub_2['_embedded']['artworks'][1].to_json, headers: {})
+    stub_request(:get, "https://api.artsy.net/api/artworks/#{@stub_2['_embedded']['artworks'][0]['id']}?X-Xapp-Token=").to_return(status: 200, body: @stub_2['_embedded']['artworks'][0].to_json, headers: {})
+    stub_request(:get, "https://api.artsy.net/api/artworks/#{@stub_2['_embedded']['artworks'][1]['id']}?X-Xapp-Token=").to_return(status: 200, body: @stub_2['_embedded']['artworks'][1].to_json, headers: {})
   end
 
   it 'can find a users liked art' do
@@ -44,6 +44,19 @@ RSpec.describe 'Rated Art Index' do
     expect(res['data'][0]['attributes']['image']).to be_a(String)
     expect(res['data'][0]['attributes']).to have_key('user_id')
     expect(res['data'][0]['attributes']['user_id']).to be_an(Integer)
+
+  end
+
+  it 'does show page thing' do
+    get "/api/v1/users/#{@u1.id}/rated_arts/#{@u1.rated_arts[0].art_id}" , params: { user_id: @u1.id, id: @u1.rated_arts[0].art_id }
+    res = JSON.parse(response.body)
+
+    expect(res['data']['id']).to eq(1)
+    expect(res['data']['type']).to eq('rated_art')
+    expect(res['data']['attributes']['title']).to eq('Der Kuss (The Kiss)')
+    expect(res['data']['attributes']['liked']).to eq(true)
+    expect(res['data']['attributes']['user_id']).to eq(@u1.id)
+    expect(res['data']['attributes']['image']).to be_a(String)
 
   end
 end


### PR DESCRIPTION
## Implemented Features:
- Add show method for rated arts show page
- Update route to include rated arts show page

## Roadblocks/Logs/Errors:
X

## Testing:
- Passes test for rated arts show page

## Notes/For the future:
- Need to ensure that this works when joined to main with the updated method for ArtSerializer that Kim and Marla built out 
